### PR TITLE
chore: add stale bot config

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,43 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 120
+
+# Number of days of inactivity before an Issue or Pull Request with the stale label is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 360
+
+# Only issues or pull requests with all of these labels are check if stale. Defaults to `[]` (disabled)
+onlyLabels: []
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - "type: bug"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Set to true to ignore issues with an assignee (defaults to false)
+exemptAssignees: false
+
+# Label to use when marking as stale
+staleLabel: "stale"
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. Please comment here if it is still valid so that we can
+  prioritize. Please add more information if necessary. Thank you!
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  Closing this. Please reopen if you believe it should be addressed. Thank you for your contribution.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 10
+
+# Limit to only `issues` or `pulls`
+only: issues


### PR DESCRIPTION
This adds configuration for the stale bot, but doesn't close an issue unless there has been 480 days since activity.