### PR TITLE
feat: add workflow to show badges on README

### DIFF
--- a/.github/workflows/workflows.sh
+++ b/.github/workflows/workflows.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+repos=$(gh repo list googleworkspace \
+    --no-archived \
+    --visibility public \
+    --source \
+    --json name --jq '.[] .name' \
+    -L 1000 | sort)
+
+FILE=README.md
+ORG=https://github.com/googleworkspace
+
+# delete all lines starting after matching string
+sed -n '/WORKFLOWS_INSERT_AFTER/q;p' <$FILE >$FILE.tmp
+mv $FILE.tmp $FILE
+
+echo "<!-- WORKFLOWS_INSERT -->" >>$FILE
+echo "Writing to $FILE"
+
+echo "## Workflows" >>$FILE
+echo "" >>$FILE
+
+echo "| Repository | Test | Lint | Release |" >>$FILE
+echo "| --- | --- | --- | --- |" >>$FILE
+
+badge() {
+    local repo=$1
+    local workflow=$2
+    echo "[![](${ORG}/${repo}/actions/workflows/${workflow}.yml/badge.svg?branch=main)](${ORG}/${repo}/actions/workflows/${workflow}.yml)"
+}
+
+for repo in $repos; do
+    echo "| [${repo}](${ORG}/${repo}) | $(badge ${repo} test) | $(badge ${repo} lint) | $(badge ${repo} release-please) |" >>$FILE
+done

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -13,7 +13,13 @@
 # limitations under the License.
 ---
 name: Workflows
-on: [workflow_dispatch, push]
+on: 
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 12 * * MON'
 jobs:
   status-badges:
     runs-on: ubuntu-latest

--- a/.github/workflows/workflows.yml
+++ b/.github/workflows/workflows.yml
@@ -1,0 +1,41 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+---
+name: Workflows
+on: [workflow_dispatch, push]
+jobs:
+  status-badges:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          # required otherwise GitHub blocks infinite loops in pushes originating in an action
+          token: ${{ secrets.GOOGLEWORKSPACE_BOT_TOKEN }}
+      - run: .github/workflows/workflows.sh
+        env:
+          GITHUB_TOKEN: ${{secrets.GOOGLEWORKSPACE_BOT_TOKEN}}
+      - uses: peter-evans/create-pull-request@10db75894f6d53fc01c3bb0995e95bd03e583a62 # v4 June 8 2022
+        with:
+          token: ${{ secrets.GOOGLEWORKSPACE_BOT_TOKEN }}
+          commit-message: "docs(README): update workflow badge table"
+          title: "docs(README): update workflow badge table"
+          branch: docs/workflow-badge-table
+          base: main
+          delete-branch: true
+          assignees: "${{ github.actor }}"
+          reviewers: "${{ github.actor }}"
+          add-paths: |
+            README.md


### PR DESCRIPTION
This creates a pr that updates the README.md with badges for all repositories. See https://github.com/googleworkspace/.github/pull/10/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5.

![image](https://user-images.githubusercontent.com/3392975/183162942-b5954518-f206-4db7-99b1-d93e7c968d50.png)


